### PR TITLE
Add custom census authorization handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,3 @@ tailwind.config.js
 Capfile
 config/deploy.rb
 config/deploy
-
-lib/assets/custom_census.csv

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ tailwind.config.js
 Capfile
 config/deploy.rb
 config/deploy
+
+lib/assets/custom_census.csv

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ Free Open-Source participatory democracy, citizen participation and open governm
 
 This is the open-source repository for decidim_inspire, based on [Decidim](https://github.com/decidim/decidim).
 
+## Custom census authorization handler
+
+This authorization handler allows users to be directly verified with their birthdates by checking the census in a CSV file.
+
+You need to create a CSV file `lib/asses/census.csv` with two columns: `email` and `birthdate`. For example:
+
+```csv
+email,date_of_birth
+john.doe@example.org,1956-03-14
+jane.smith@example.org,1998-12-06
+```
+
+The verification will succeed if the user is in the census and introduces the same birthdate as the one in the CSV.
+
+This authorization handler will allow us to work with the [Decidim Kids](https://github.com/AjuntamentdeBarcelona/decidim-module-kids) module.
+
 ## Setting up the application
 
 You will need to do some steps before having the app working properly once you have deployed it:

--- a/README.md
+++ b/README.md
@@ -10,17 +10,20 @@ This is the open-source repository for decidim_inspire, based on [Decidim](https
 
 ## Custom census authorization handler
 
-This authorization handler allows users to be directly verified with their birthdates by checking the census in a CSV file.
+This authorization handler allows users to be directly verified with their birthdates by checking the records in a table.
 
-You need to create a CSV file `lib/asses/census.csv` with two columns: `email` and `birthdate`. For example:
+You need to create records for the model `Decidim::CustomCensusRecord`. For example:
 
-```csv
-email,date_of_birth
-john.doe@example.org,1956-03-14
-jane.smith@example.org,1998-12-06
+```ruby
+[
+  { email: "john.doe@example.org", date_of_birth: "1956-03-14" },
+  { email: "jane.smith@example.org", date_of_birth: "1998-12-06" }
+].each do |record|
+  Decidim::CustomCensusRecord.create(email: record[:email], metadata: { date_of_birth: record[:date_of_birth] })
+end
 ```
 
-The verification will succeed if the user is in the census and introduces the same birthdate as the one in the CSV.
+The verification will succeed if the user is in the census and introduces the same birthdate as the one in the database.
 
 This authorization handler will allow us to work with the [Decidim Kids](https://github.com/AjuntamentdeBarcelona/decidim-module-kids) module.
 

--- a/app/models/decidim/custom_census_record.rb
+++ b/app/models/decidim/custom_census_record.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  class CustomCensusRecord < ApplicationRecord
+    include Decidim::RecordEncryptor
+
+    validates :email, uniqueness: true
+
+    encrypt_attribute :metadata, type: :hash
+
+    def date_of_birth
+      metadata["date_of_birth"]
+    end
+  end
+end

--- a/app/services/custom_census_authorization_handler.rb
+++ b/app/services/custom_census_authorization_handler.rb
@@ -26,13 +26,9 @@ class CustomCensusAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def present_in_census
-    result = census.find { |row| row["email"] == user.email }
-    return errors.add(:base, I18n.t("custom_census_authorization_handler.errors.not_found")) unless result
+    record = Decidim::CustomCensusRecord.find_by(email: user.email)
+    return errors.add(:base, I18n.t("custom_census_authorization_handler.errors.not_found")) unless record
 
-    errors.add(:date_of_birth, I18n.t("custom_census_authorization_handler.errors.invalid_date_of_birth")) unless result["date_of_birth"] == parsed_date_of_birth
-  end
-
-  def census
-    @census ||= CSV.read(Rails.root.join("lib/assets/custom_census.csv"), headers: true)
+    errors.add(:date_of_birth, I18n.t("custom_census_authorization_handler.errors.invalid_date_of_birth")) unless record.date_of_birth == parsed_date_of_birth
   end
 end

--- a/app/services/custom_census_authorization_handler.rb
+++ b/app/services/custom_census_authorization_handler.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Checks the authorization against the census for Barcelona.
+require "digest/md5"
+
+# This class performs a check against the census file in order to verify the citizen's residence.
+class CustomCensusAuthorizationHandler < Decidim::AuthorizationHandler
+  attribute :date_of_birth, Date
+
+  validates :date_of_birth, presence: true
+
+  validate :present_in_census
+
+  def metadata
+    super.merge(date_of_birth: parsed_date_of_birth)
+  end
+
+  def unique_id
+    Digest::MD5.hexdigest("#{user.email}-#{Rails.application.secrets.secret_key_base}")
+  end
+
+  private
+
+  def parsed_date_of_birth
+    @parsed_date_of_birth ||= date_of_birth&.strftime("%Y-%m-%d")
+  end
+
+  def present_in_census
+    result = census.find { |row| row["email"] == user.email }
+    return errors.add(:base, I18n.t("custom_census_authorization_handler.errors.not_found")) unless result
+
+    errors.add(:date_of_birth, I18n.t("custom_census_authorization_handler.errors.invalid_date_of_birth")) unless result["date_of_birth"] == parsed_date_of_birth
+  end
+
+  def census
+    @census ||= CSV.read(Rails.root.join("lib/assets/custom_census.csv"), headers: true)
+  end
+end

--- a/app/views/custom_census_authorization/_form.html.erb
+++ b/app/views/custom_census_authorization/_form.html.erb
@@ -1,0 +1,7 @@
+<div class="form__wrapper">
+  <div class="field date">
+    <%= form.date_select :date_of_birth, start_year: 1900, end_year: 1.year.ago.year, default: 20.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+  </div>
+
+  <%= form.hidden_field :handler_name %>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -11,3 +11,5 @@ ignore_missing:
   - layouts.decidim.footer.cc_by_license
   - layouts.decidim.footer.decidim_logo
   - layouts.decidim.footer.made_with_open_source
+  - custom_census_authorization.form.*
+  - custom_census_authorization_handler.errors.*

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -494,3 +494,9 @@ Rails.application.config.i18n.default_locale = Decidim.default_locale
 
 # Inform Decidim about the assets folder
 Decidim.register_assets_path File.expand_path("app/packs", Rails.application.root)
+
+Decidim::Verifications.register_workflow(:custom_census_authorization_handler) do |auth|
+  auth.form = "CustomCensusAuthorizationHandler"
+  auth.renewable = true
+  auth.time_between_renewals = 1.day
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,1 +1,27 @@
 en:
+  activemodel:
+    attributes:
+      custom_census_authorization_handler:
+        date_of_birth: Date of birth
+  custom_census_authorization:
+    form:
+      date_select:
+        day: Day
+        month: Month
+        year: Year
+  custom_census_authorization_handler:
+    errors:
+      not_found: The user is not present in the census
+      invalid_date_of_birth: The date of birth is not correct
+  decidim:
+    authorization_handlers:
+      custom_census_authorization_handler:
+        explanation: Verify against the custom census authorization handler
+        fields:
+          date_of_birth: Date of birth
+        name: Custom census
+    verifications:
+      authorizations:
+        first_login:
+          actions:
+            custom_census_authorization_handler: Verify against the custom census authorization handler

--- a/db/migrate/20250115084854_create_decidim_custom_census_records.rb
+++ b/db/migrate/20250115084854_create_decidim_custom_census_records.rb
@@ -1,0 +1,13 @@
+class CreateDecidimCustomCensusRecords < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_custom_census_records do |t|
+      t.string :email, null: false
+      t.jsonb :metadata
+
+      Decidim::Authorization
+      t.timestamps
+    end
+
+    add_index :decidim_custom_census_records, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_11_083926) do
+ActiveRecord::Schema.define(version: 2025_01_15_084854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -548,6 +548,14 @@ ActiveRecord::Schema.define(version: 2024_10_11_083926) do
     t.jsonb "content", null: false
     t.index ["organization_id"], name: "index_decidim_contextual_help_sections_on_organization_id"
     t.index ["section_id"], name: "index_decidim_contextual_help_sections_on_section_id"
+  end
+
+  create_table "decidim_custom_census_records", force: :cascade do |t|
+    t.string "email", null: false
+    t.jsonb "metadata"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_decidim_custom_census_records_on_email", unique: true
   end
 
   create_table "decidim_debates_debates", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This authorization handler allows users to be directly verified with their birthdates by checking the records in a table.

You need to create records for the model `Decidim::CustomCensusRecord`. For example:

```ruby
[
  { email: "john.doe@example.org", date_of_birth: "1956-03-14" },
  { email: "jane.smith@example.org", date_of_birth: "1998-12-06" }
].each do |record|
  Decidim::CustomCensusRecord.create(email: record[:email], metadata: { date_of_birth: record[:date_of_birth] })
end
```

The verification will succeed if the user is in the census and introduces the same birthdate as the one in the database.

This authorization handler will allow us to work with the [Decidim Kids](https://github.com/AjuntamentdeBarcelona/decidim-module-kids) module.