### PR TITLE
Add/fix email subject translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,4 +28,4 @@ en:
   devise:
     mailer:
       invite_minor:
-        subject: Invitation for an INSPIRE minor account
+        subject: Invitation to the INSPIRE Decidim Youth Platform

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,5 +27,5 @@ en:
             custom_census_authorization_handler: Verify against the custom census authorization handler
   devise:
     mailer:
-      invite_minors:
+      invite_minor:
         subject: Invitation for an INSPIRE minor account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,3 +25,7 @@ en:
         first_login:
           actions:
             custom_census_authorization_handler: Verify against the custom census authorization handler
+  devise:
+    mailer:
+      invite_minors:
+        subject: Invitation for an INSPIRE minor account


### PR DESCRIPTION
## This will fix the subject in the email:

### Old:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/abf8c20e-52b0-411f-8eee-29a92420e715" />

### New:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/7878d48b-445e-40d8-a53a-0ae8488bb519" />