### PR TITLE
Bump `decidim-superspaces` version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,11 @@ GIT
 
 GIT
   remote: https://github.com/Platoniq/decidim-superspace
-  revision: 2e0f59da545189647b1386b5ae3a9ed6c3dcec0f
+  revision: 691fc07df6e1ef61b16036d1899f10425886e167
   branch: main
   specs:
     decidim-superspaces (0.1.0)
+      decidim-conferences (>= 0.28.0, < 0.29)
       decidim-core (>= 0.28.0, < 0.29)
 
 GIT
@@ -423,7 +424,8 @@ GEM
       temple
     erubi (1.13.1)
     escape_utils (1.2.2)
-    excon (1.2.3)
+    excon (1.2.5)
+      logger
     extended-markdown-filter (0.7.0)
       html-pipeline (~> 2.9)
     factory_bot (6.5.1)
@@ -439,7 +441,8 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0)
+    ffi (1.17.1)
+    ffi (1.17.1-x86_64-linux-gnu)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     file_validators (3.0.0)
@@ -557,7 +560,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0204)
+    mime-types-data (3.2025.0220)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
@@ -606,7 +609,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (2.1.2)
+    omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -661,7 +664,7 @@ GEM
     puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.11)
+    rack (2.2.12)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-cors (1.1.1)
@@ -852,7 +855,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     ssrf_filter (1.2.0)
-    stringio (3.1.3)
+    stringio (3.1.5)
     strscan (3.1.2)
     temple (0.10.3)
     terminal-table (4.0.0)
@@ -867,11 +870,11 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.6.0)
     uniform_notifier (1.16.0)
-    uri (1.0.2)
+    uri (1.0.3)
     valid_email2 (4.0.6)
       activemodel (>= 3.2)
       mail (~> 2.5)
-    version_gem (1.1.4)
+    version_gem (1.1.6)
     w3c_rspec_validators (0.3.0)
       rails
       rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,8 +441,7 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.1)
-    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     file_validators (3.0.0)

--- a/db/migrate/20250304152053_add_description_to_decidim_superspaces.decidim_superspaces.rb
+++ b/db/migrate/20250304152053_add_description_to_decidim_superspaces.decidim_superspaces.rb
@@ -1,0 +1,6 @@
+# This migration comes from decidim_superspaces (originally 20250211124922)
+class AddDescriptionToDecidimSuperspaces < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_superspaces_superspaces, :description, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_07_075165) do
+ActiveRecord::Schema.define(version: 2025_03_04_152053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1709,6 +1709,7 @@ ActiveRecord::Schema.define(version: 2025_02_07_075165) do
     t.string "locale"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "description"
     t.index ["decidim_organization_id"], name: "index_decidim_superspaces_superspaces_on_decidim_organization"
   end
 


### PR DESCRIPTION
Our repo had not synced with the superspace module to get the description field for a superspace.