### PR TITLE
Backport Admin Image Upload Patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby RUBY_VERSION
 
 DECIDIM_VERSION = "0.28.5"
 
-gem "decidim", DECIDIM_VERSION
+gem "decidim", git: "https://github.com/decidim/decidim.git", branch: "release/0.28-stable"
 gem "decidim-conferences", DECIDIM_VERSION
 # gem "decidim-design", DECIDIM_VERSION
 # gem "decidim-elections", DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,32 @@ GIT
       deface (~> 1.5)
 
 GIT
+  remote: https://github.com/decidim/decidim.git
+  revision: b90ed8b774b23d7c41f261f1a10bb1d143d8905e
+  branch: release/0.28-stable
+  specs:
+    decidim (0.28.5)
+      decidim-accountability (= 0.28.5)
+      decidim-admin (= 0.28.5)
+      decidim-api (= 0.28.5)
+      decidim-assemblies (= 0.28.5)
+      decidim-blogs (= 0.28.5)
+      decidim-budgets (= 0.28.5)
+      decidim-comments (= 0.28.5)
+      decidim-core (= 0.28.5)
+      decidim-debates (= 0.28.5)
+      decidim-forms (= 0.28.5)
+      decidim-generators (= 0.28.5)
+      decidim-meetings (= 0.28.5)
+      decidim-pages (= 0.28.5)
+      decidim-participatory_processes (= 0.28.5)
+      decidim-proposals (= 0.28.5)
+      decidim-sortitions (= 0.28.5)
+      decidim-surveys (= 0.28.5)
+      decidim-system (= 0.28.5)
+      decidim-verifications (= 0.28.5)
+
+GIT
   remote: https://github.com/mainio/decidim-module-term_customizer
   revision: 9133eea57ebfc4164b640efd1ac6b9ca1628c793
   branch: main
@@ -209,26 +235,6 @@ GEM
     date_validator (0.12.0)
       activemodel (>= 3)
       activesupport (>= 3)
-    decidim (0.28.5)
-      decidim-accountability (= 0.28.5)
-      decidim-admin (= 0.28.5)
-      decidim-api (= 0.28.5)
-      decidim-assemblies (= 0.28.5)
-      decidim-blogs (= 0.28.5)
-      decidim-budgets (= 0.28.5)
-      decidim-comments (= 0.28.5)
-      decidim-core (= 0.28.5)
-      decidim-debates (= 0.28.5)
-      decidim-forms (= 0.28.5)
-      decidim-generators (= 0.28.5)
-      decidim-meetings (= 0.28.5)
-      decidim-pages (= 0.28.5)
-      decidim-participatory_processes (= 0.28.5)
-      decidim-proposals (= 0.28.5)
-      decidim-sortitions (= 0.28.5)
-      decidim-surveys (= 0.28.5)
-      decidim-system (= 0.28.5)
-      decidim-verifications (= 0.28.5)
     decidim-accountability (0.28.5)
       decidim-comments (= 0.28.5)
       decidim-core (= 0.28.5)
@@ -927,7 +933,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv
   capistrano-sidekiq
-  decidim (= 0.28.5)
+  decidim!
   decidim-conferences (= 0.28.5)
   decidim-decidim_awesome
   decidim-dev (= 0.28.5)


### PR DESCRIPTION
This backports the fix to allow process admins to upload media.
You can find the PR [here](https://github.com/decidim/decidim/pull/13772)